### PR TITLE
Use default Linux shell

### DIFF
--- a/main.js
+++ b/main.js
@@ -32,7 +32,7 @@ app.on('ready', () => {
     globalShortcut.register("F12", () => mainWindow.webContents.openDevTools({ mode: 'detach' }));
 
     ipcMain.on('start-terminal', (event) => {
-        const shell = platform() === 'win32' ? 'powershell.exe' : 'bash'; // Afhankelijk van het platform
+        const shell = platform() === 'win32' ? 'powershell.exe' : process.env.SHELL; // Afhankelijk van het platform
 
         const terminal = spawn(shell, [], {
             name: 'xterm-256color',


### PR DESCRIPTION
Since I'm using `zsh`, I like to complain about wshell loading `bash` by default. So, I made this pull request.

Merge plz ^_^